### PR TITLE
docs: fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First, make sure you have the Go programming language installed on your system. 
 To install the `git2gpt` utility, run the following command:
 
 ```bash
-go install github.com/chand1012/git2gpt
+go install github.com/chand1012/git2gpt@latest
 ```
 
 This command will download and install the git2gpt binary to your `$GOPATH/bin` directory. Make sure your `$GOPATH/bin` is included in your `$PATH` to use the `git2gpt` command.


### PR DESCRIPTION
At least for me I had to install using the suffix, otherwise I got an error. 
May be related to [this](https://go.dev/doc/go-get-install-deprecation#what-to-use-instead)